### PR TITLE
Feature/read only sql and catalog packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ are trademarks of Databricks, Inc.
 - Read-only Unity Catalog exploration: catalogs, schemas, tables, views,
   columns, functions, and volumes
 - Read-only Databricks SQL warehouse discovery
+- AST-validated read-only SQL execution (sqlglot) with row, byte, and time
+  limits, plus statement polling and cancellation
 - A capability-pack architecture with a policy-enforcing tool registry
 - A deny-by-default policy foundation for future mutation tools
 - Typed configuration, structured errors, tests, CI, and a non-root container
@@ -117,6 +119,10 @@ TLS until native remote authorization lands in Phase 3.
 | `DATABRICKS_MCP_PORT` | `8000` | HTTP bind port |
 | `DATABRICKS_MCP_LOG_LEVEL` | `INFO` | Python log level |
 | `DATABRICKS_MCP_ACCESS_MODE` | `read-only` | Policy mode; only `read-only` exists in Phase 1 |
+| `DATABRICKS_MCP_SQL_MAX_ROWS` | `1000` | Maximum rows returned by read-only SQL (ceiling) |
+| `DATABRICKS_MCP_SQL_BYTE_LIMIT` | `10000000` | Maximum result bytes for read-only SQL |
+| `DATABRICKS_MCP_SQL_WAIT_SECONDS` | `30` | Synchronous wait before a statement returns a poll id (5–50) |
+| `DATABRICKS_MCP_SQL_WAREHOUSES` | _unset_ | Optional comma-separated warehouse-id allowlist for SQL |
 
 Standard `DATABRICKS_*` authentication variables are consumed by the official
 Databricks SDK.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ are trademarks of Databricks, Inc.
 
 - MCP over local `stdio` and remote Streamable HTTP
 - Databricks unified authentication through the official Python SDK
-- Health and authenticated-identity diagnostics
-- Read-only Unity Catalog and SQL warehouse discovery
+- Health, identity, and capability-introspection diagnostics
+- Read-only Unity Catalog exploration: catalogs, schemas, tables, views,
+  columns, functions, and volumes
+- Read-only Databricks SQL warehouse discovery
+- A capability-pack architecture with a policy-enforcing tool registry
 - A deny-by-default policy foundation for future mutation tools
 - Typed configuration, structured errors, tests, CI, and a non-root container
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,10 +11,14 @@ until the project has a stable maintainer cadence.
 - [x] Health, current identity, catalog, and warehouse tools
 - [x] Deny-by-default policy foundation
 - [x] Unit tests, CI, container, and security documentation
+- [x] Capability-pack architecture with a policy-enforcing tool registry
+- [x] Capability introspection (`server_info`, `list_enabled_capabilities`, `get_policy_status`)
+- [x] Unity Catalog metadata exploration (schemas, tables, views, columns, functions, volumes)
+- [x] Mock-SDK contract tests for every read tool
 - [ ] Read-only SQL with AST validation and bounded results
-- [ ] Catalog/schema/table metadata exploration
 - [ ] Read-only jobs, pipeline, and cluster inspection
-- [ ] Mock-server contract tests and opt-in workspace integration tests
+- [ ] Consistent cursor pagination for large listings
+- [ ] Opt-in live-workspace integration tests
 
 ## Phase 2 — Controlled operations
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ until the project has a stable maintainer cadence.
 - [x] Capability introspection (`server_info`, `list_enabled_capabilities`, `get_policy_status`)
 - [x] Unity Catalog metadata exploration (schemas, tables, views, columns, functions, volumes)
 - [x] Mock-SDK contract tests for every read tool
-- [ ] Read-only SQL with AST validation and bounded results
+- [x] Read-only SQL with sqlglot AST validation, bounded results, and cancellation
 - [ ] Read-only jobs, pipeline, and cluster inspection
 - [ ] Consistent cursor pagination for large listings
 - [ ] Opt-in live-workspace integration tests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,8 +35,15 @@ Databricks workspace/account APIs
 - `policy.py`: capability classification and authorization decisions.
 - `serialization.py`: bounded conversion of SDK models to JSON values.
 - `services.py`: Databricks SDK adapter layer.
-- `server.py`: MCP tool registration only.
+- `registry.py`: `ToolSpec` metadata and the `Registrar`, which enforces the
+  policy engine and records tool metadata on every registration.
+- `packs/`: capability packs, one module per Databricks domain
+  (`core`, `catalog`, `sql`, ...). Each exposes a `register(registrar)` function.
+- `server.py`: builds the server, wires the registrar, and registers packs.
 - `__main__.py`: process startup and transport selection.
 
-Future capability packs will live under `tools/` and `services/` namespaces once
-the initial contracts have been validated with multiple MCP clients.
+Each pack is registered through the `Registrar`, so every tool is guarded by the
+policy engine and carries a declared risk class and operational metadata. New
+domains are added by dropping a module in `packs/` and listing it in
+`packs/__init__.py`; service methods for that domain live in `services.py` until
+the domain grows enough modules to warrant its own `services/` subpackage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
   "databricks-sdk>=0.57.0,<1",
   "mcp>=1.9.0,<2",
+  "sqlglot>=25,<28",
 ]
 
 [project.urls]
@@ -59,6 +60,10 @@ quote-style = "double"
 python_version = "3.11"
 strict = true
 packages = ["databricks_mcp"]
+
+[[tool.mypy.overrides]]
+module = ["sqlglot.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--strict-config --strict-markers --cov=databricks_mcp --cov-report=term-missing"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 addopts = "--strict-config --strict-markers --cov=databricks_mcp --cov-report=term-missing"
 testpaths = ["tests"]
+pythonpath = ["."]
 
 [tool.coverage.run]
 branch = true

--- a/src/databricks_mcp/config.py
+++ b/src/databricks_mcp/config.py
@@ -21,6 +21,11 @@ def _integer(name: str, default: int, *, minimum: int, maximum: int) -> int:
     return value
 
 
+def _string_tuple(name: str) -> tuple[str, ...]:
+    raw = os.getenv(name, "")
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
+
+
 @dataclass(frozen=True, slots=True)
 class Settings:
     """Runtime settings loaded from environment variables."""
@@ -32,6 +37,10 @@ class Settings:
     access_mode: AccessMode = "read-only"
     default_page_size: int = 100
     maximum_page_size: int = 200
+    sql_max_rows: int = 1000
+    sql_byte_limit: int = 10_000_000
+    sql_wait_seconds: int = 30
+    sql_warehouse_allowlist: tuple[str, ...] = ()
 
     @classmethod
     def from_env(cls) -> Settings:
@@ -58,4 +67,13 @@ class Settings:
                 "DATABRICKS_MCP_DEFAULT_PAGE_SIZE", 100, minimum=1, maximum=200
             ),
             maximum_page_size=200,
+            sql_max_rows=_integer("DATABRICKS_MCP_SQL_MAX_ROWS", 1000, minimum=1, maximum=100_000),
+            sql_byte_limit=_integer(
+                "DATABRICKS_MCP_SQL_BYTE_LIMIT",
+                10_000_000,
+                minimum=1_000,
+                maximum=100_000_000,
+            ),
+            sql_wait_seconds=_integer("DATABRICKS_MCP_SQL_WAIT_SECONDS", 30, minimum=5, maximum=50),
+            sql_warehouse_allowlist=_string_tuple("DATABRICKS_MCP_SQL_WAREHOUSES"),
         )

--- a/src/databricks_mcp/packs/__init__.py
+++ b/src/databricks_mcp/packs/__init__.py
@@ -1,0 +1,27 @@
+"""Capability packs and their registration entry point."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+from databricks_mcp.packs import catalog, core, sql
+
+if TYPE_CHECKING:
+    from databricks_mcp.registry import Registrar
+
+
+class Pack(Protocol):
+    """A capability pack module: a name and a registration function."""
+
+    NAME: str
+
+    def register(self, registrar: Registrar) -> None: ...
+
+
+DEFAULT_PACKS: tuple[Pack, ...] = (core, catalog, sql)
+
+
+def register_all(registrar: Registrar) -> None:
+    """Register every default capability pack onto the server."""
+    for pack in DEFAULT_PACKS:
+        pack.register(registrar)

--- a/src/databricks_mcp/packs/catalog.py
+++ b/src/databricks_mcp/packs/catalog.py
@@ -1,0 +1,183 @@
+"""Unity Catalog read pack: catalogs, schemas, tables, columns, functions, volumes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from databricks_mcp.policy import RiskClass
+from databricks_mcp.registry import ToolSpec
+
+if TYPE_CHECKING:
+    from databricks_mcp.registry import Registrar
+
+NAME = "catalog"
+
+
+def register(registrar: Registrar) -> None:
+    default_limit = registrar.settings.default_page_size
+    limit_of = registrar.checked_limit
+
+    @registrar.tool(
+        ToolSpec(
+            "list_catalogs",
+            NAME,
+            RiskClass.READ,
+            "List accessible Unity Catalog catalogs, bounded to the configured page size.",
+        )
+    )
+    def list_catalogs(limit: int = default_limit) -> list[dict[str, Any]]:
+        return registrar.service.list_catalogs(limit=limit_of(limit))
+
+    @registrar.tool(
+        ToolSpec(
+            "get_catalog",
+            NAME,
+            RiskClass.READ,
+            "Get metadata for one Unity Catalog catalog by name.",
+        )
+    )
+    def get_catalog(name: str) -> dict[str, Any]:
+        return registrar.service.get_catalog(name)
+
+    @registrar.tool(
+        ToolSpec(
+            "list_schemas",
+            NAME,
+            RiskClass.READ,
+            "List schemas within a catalog, bounded to the page size.",
+        )
+    )
+    def list_schemas(catalog_name: str, limit: int = default_limit) -> list[dict[str, Any]]:
+        return registrar.service.list_schemas(catalog_name=catalog_name, limit=limit_of(limit))
+
+    @registrar.tool(
+        ToolSpec(
+            "get_schema",
+            NAME,
+            RiskClass.READ,
+            "Get metadata for one schema by its full name (catalog.schema).",
+        )
+    )
+    def get_schema(full_name: str) -> dict[str, Any]:
+        return registrar.service.get_schema(full_name)
+
+    @registrar.tool(
+        ToolSpec(
+            "list_tables",
+            NAME,
+            RiskClass.READ,
+            "List tables within a schema, bounded to the page size.",
+        )
+    )
+    def list_tables(
+        catalog_name: str, schema_name: str, limit: int = default_limit
+    ) -> list[dict[str, Any]]:
+        return registrar.service.list_tables(
+            catalog_name=catalog_name, schema_name=schema_name, limit=limit_of(limit)
+        )
+
+    @registrar.tool(
+        ToolSpec(
+            "list_views",
+            NAME,
+            RiskClass.READ,
+            "List views and materialized views within a schema, bounded to the page size.",
+        )
+    )
+    def list_views(
+        catalog_name: str, schema_name: str, limit: int = default_limit
+    ) -> list[dict[str, Any]]:
+        return registrar.service.list_views(
+            catalog_name=catalog_name, schema_name=schema_name, limit=limit_of(limit)
+        )
+
+    @registrar.tool(
+        ToolSpec(
+            "get_table",
+            NAME,
+            RiskClass.READ,
+            "Get full metadata for one table by its full name (catalog.schema.table).",
+        )
+    )
+    def get_table(full_name: str) -> dict[str, Any]:
+        return registrar.service.get_table(full_name)
+
+    @registrar.tool(
+        ToolSpec(
+            "describe_table",
+            NAME,
+            RiskClass.READ,
+            "Return a concise table summary: type, comment, and columns with types.",
+        )
+    )
+    def describe_table(full_name: str) -> dict[str, Any]:
+        table = registrar.service.get_table(full_name)
+        raw_columns = table.get("columns")
+        columns: list[dict[str, Any]] = []
+        if isinstance(raw_columns, list):
+            for column in raw_columns:
+                if isinstance(column, dict):
+                    columns.append(
+                        {
+                            "name": column.get("name"),
+                            "type": column.get("type_text") or column.get("type_name"),
+                            "nullable": column.get("nullable"),
+                            "comment": column.get("comment"),
+                        }
+                    )
+        return {
+            "full_name": table.get("full_name"),
+            "catalog_name": table.get("catalog_name"),
+            "schema_name": table.get("schema_name"),
+            "name": table.get("name"),
+            "table_type": table.get("table_type"),
+            "data_source_format": table.get("data_source_format"),
+            "comment": table.get("comment"),
+            "columns": columns,
+        }
+
+    @registrar.tool(
+        ToolSpec(
+            "list_columns", NAME, RiskClass.READ, "List the columns of one table by its full name."
+        )
+    )
+    def list_columns(full_name: str) -> list[dict[str, Any]]:
+        return registrar.service.list_columns(full_name)
+
+    @registrar.tool(
+        ToolSpec(
+            "list_functions",
+            NAME,
+            RiskClass.READ,
+            "List user-defined functions within a schema, bounded to the page size.",
+        )
+    )
+    def list_functions(
+        catalog_name: str, schema_name: str, limit: int = default_limit
+    ) -> list[dict[str, Any]]:
+        return registrar.service.list_functions(
+            catalog_name=catalog_name, schema_name=schema_name, limit=limit_of(limit)
+        )
+
+    @registrar.tool(
+        ToolSpec(
+            "get_function", NAME, RiskClass.READ, "Get metadata for one function by its full name."
+        )
+    )
+    def get_function(name: str) -> dict[str, Any]:
+        return registrar.service.get_function(name)
+
+    @registrar.tool(
+        ToolSpec(
+            "list_volumes",
+            NAME,
+            RiskClass.READ,
+            "List Unity Catalog volumes within a schema, bounded to the page size.",
+        )
+    )
+    def list_volumes(
+        catalog_name: str, schema_name: str, limit: int = default_limit
+    ) -> list[dict[str, Any]]:
+        return registrar.service.list_volumes(
+            catalog_name=catalog_name, schema_name=schema_name, limit=limit_of(limit)
+        )

--- a/src/databricks_mcp/packs/core.py
+++ b/src/databricks_mcp/packs/core.py
@@ -1,0 +1,93 @@
+"""Core diagnostics pack: health, identity, and capability introspection."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from databricks_mcp import __version__
+from databricks_mcp.policy import Capability, RiskClass
+from databricks_mcp.registry import ToolSpec
+
+if TYPE_CHECKING:
+    from databricks_mcp.registry import Registrar
+
+NAME = "core"
+
+
+def register(registrar: Registrar) -> None:
+    settings = registrar.settings
+
+    @registrar.tool(
+        ToolSpec(
+            "health",
+            NAME,
+            RiskClass.READ,
+            "Return process health without accessing Databricks or exposing credentials.",
+        )
+    )
+    def health() -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "version": __version__,
+            "access_mode": settings.access_mode,
+            "transport": settings.transport,
+        }
+
+    @registrar.tool(
+        ToolSpec(
+            "server_info",
+            NAME,
+            RiskClass.READ,
+            "Return server identity, version, transport, and enabled capability packs.",
+        )
+    )
+    def server_info() -> dict[str, Any]:
+        specs = registrar.specs
+        packs = sorted({spec.pack for spec in specs.values()})
+        return {
+            "name": "DatabricksMCP",
+            "version": __version__,
+            "transport": settings.transport,
+            "access_mode": settings.access_mode,
+            "packs": packs,
+            "tool_count": len(specs),
+        }
+
+    @registrar.tool(
+        ToolSpec(
+            "list_enabled_capabilities",
+            NAME,
+            RiskClass.READ,
+            "List every enabled tool with its risk classification and operational metadata.",
+        )
+    )
+    def list_enabled_capabilities() -> list[dict[str, Any]]:
+        specs = sorted(registrar.specs.values(), key=lambda spec: (spec.pack, spec.name))
+        return [spec.describe() for spec in specs]
+
+    @registrar.tool(
+        ToolSpec(
+            "get_policy_status",
+            NAME,
+            RiskClass.READ,
+            "Return the current access mode and which risk classes are permitted.",
+        )
+    )
+    def get_policy_status() -> dict[str, Any]:
+        allowed = [
+            risk.value
+            for risk in RiskClass
+            if registrar.policy.authorize(Capability(name="_probe", risk=risk)).allowed
+        ]
+        return {"access_mode": settings.access_mode, "allowed_risk_classes": allowed}
+
+    @registrar.tool(
+        ToolSpec(
+            "current_identity",
+            NAME,
+            RiskClass.READ,
+            "Return the Databricks identity selected by unified authentication.",
+        )
+    )
+    def current_identity() -> dict[str, Any]:
+        return registrar.service.current_identity()

--- a/src/databricks_mcp/packs/sql.py
+++ b/src/databricks_mcp/packs/sql.py
@@ -1,7 +1,10 @@
-"""Databricks SQL read pack: SQL warehouse discovery.
+"""Databricks SQL pack: warehouse discovery and bounded read-only SQL.
 
-Read-only SQL execution (``execute_read_only_sql`` with AST validation and
-bounded results) is planned for the next increment and will join this pack.
+``execute_read_only_sql`` validates every statement with the sqlglot-based guard
+(:mod:`databricks_mcp.sqlguard`) before it reaches a warehouse, and bounds the
+result by rows, bytes, and wait time. Long-running statements return a
+statement id the caller can poll with ``get_sql_statement`` or stop with
+``cancel_sql_statement``.
 """
 
 from __future__ import annotations
@@ -10,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 from databricks_mcp.policy import RiskClass
 from databricks_mcp.registry import ToolSpec
+from databricks_mcp.sqlguard import validate_read_only_sql
 
 if TYPE_CHECKING:
     from databricks_mcp.registry import Registrar
@@ -18,8 +22,23 @@ NAME = "sql"
 
 
 def register(registrar: Registrar) -> None:
-    default_limit = registrar.settings.default_page_size
+    settings = registrar.settings
+    default_limit = settings.default_page_size
     limit_of = registrar.checked_limit
+
+    def resolve_warehouse(warehouse_id: str) -> str:
+        warehouse_id = warehouse_id.strip()
+        if not warehouse_id:
+            raise ValueError("warehouse_id is required")
+        allowlist = settings.sql_warehouse_allowlist
+        if allowlist and warehouse_id not in allowlist:
+            raise ValueError(f"warehouse '{warehouse_id}' is not in the configured allowlist")
+        return warehouse_id
+
+    def clamp_rows(max_rows: int) -> int:
+        if max_rows < 1:
+            raise ValueError("max_rows must be greater than zero")
+        return min(max_rows, settings.sql_max_rows)
 
     @registrar.tool(
         ToolSpec(
@@ -41,4 +60,79 @@ def register(registrar: Registrar) -> None:
         )
     )
     def get_sql_warehouse(warehouse_id: str) -> dict[str, Any]:
-        return registrar.service.get_warehouse(warehouse_id)
+        return registrar.service.get_warehouse(resolve_warehouse(warehouse_id))
+
+    @registrar.tool(
+        ToolSpec(
+            "execute_read_only_sql",
+            NAME,
+            RiskClass.READ,
+            "Run an AST-validated read-only SQL query on a warehouse, bounded by "
+            "rows, bytes, and wait time. Only SELECT/SHOW/DESCRIBE/EXPLAIN are allowed.",
+        )
+    )
+    def execute_read_only_sql(
+        statement: str,
+        warehouse_id: str,
+        max_rows: int = settings.sql_max_rows,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> dict[str, Any]:
+        safe_statement = validate_read_only_sql(statement)
+        return registrar.service.execute_read_only_sql(
+            statement=safe_statement,
+            warehouse_id=resolve_warehouse(warehouse_id),
+            row_limit=clamp_rows(max_rows),
+            byte_limit=settings.sql_byte_limit,
+            wait_seconds=settings.sql_wait_seconds,
+            catalog=catalog,
+            schema=schema,
+        )
+
+    @registrar.tool(
+        ToolSpec(
+            "explain_sql",
+            NAME,
+            RiskClass.READ,
+            "Return the query plan for a read-only SQL query without returning rows.",
+        )
+    )
+    def explain_sql(
+        statement: str,
+        warehouse_id: str,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> dict[str, Any]:
+        validate_read_only_sql(statement)
+        explain_statement = validate_read_only_sql(f"EXPLAIN {statement}")
+        return registrar.service.execute_read_only_sql(
+            statement=explain_statement,
+            warehouse_id=resolve_warehouse(warehouse_id),
+            row_limit=settings.sql_max_rows,
+            byte_limit=settings.sql_byte_limit,
+            wait_seconds=settings.sql_wait_seconds,
+            catalog=catalog,
+            schema=schema,
+        )
+
+    @registrar.tool(
+        ToolSpec(
+            "get_sql_statement",
+            NAME,
+            RiskClass.READ,
+            "Poll the status and bounded result of a previously submitted statement.",
+        )
+    )
+    def get_sql_statement(statement_id: str) -> dict[str, Any]:
+        return registrar.service.get_sql_statement(statement_id)
+
+    @registrar.tool(
+        ToolSpec(
+            "cancel_sql_statement",
+            NAME,
+            RiskClass.READ,
+            "Cancel a running SQL statement by its id.",
+        )
+    )
+    def cancel_sql_statement(statement_id: str) -> dict[str, Any]:
+        return registrar.service.cancel_sql_statement(statement_id)

--- a/src/databricks_mcp/packs/sql.py
+++ b/src/databricks_mcp/packs/sql.py
@@ -1,0 +1,44 @@
+"""Databricks SQL read pack: SQL warehouse discovery.
+
+Read-only SQL execution (``execute_read_only_sql`` with AST validation and
+bounded results) is planned for the next increment and will join this pack.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from databricks_mcp.policy import RiskClass
+from databricks_mcp.registry import ToolSpec
+
+if TYPE_CHECKING:
+    from databricks_mcp.registry import Registrar
+
+NAME = "sql"
+
+
+def register(registrar: Registrar) -> None:
+    default_limit = registrar.settings.default_page_size
+    limit_of = registrar.checked_limit
+
+    @registrar.tool(
+        ToolSpec(
+            "list_sql_warehouses",
+            NAME,
+            RiskClass.READ,
+            "List accessible SQL warehouses, bounded to the configured page size.",
+        )
+    )
+    def list_sql_warehouses(limit: int = default_limit) -> list[dict[str, Any]]:
+        return registrar.service.list_warehouses(limit=limit_of(limit))
+
+    @registrar.tool(
+        ToolSpec(
+            "get_sql_warehouse",
+            NAME,
+            RiskClass.READ,
+            "Get configuration and state for one SQL warehouse by its id.",
+        )
+    )
+    def get_sql_warehouse(warehouse_id: str) -> dict[str, Any]:
+        return registrar.service.get_warehouse(warehouse_id)

--- a/src/databricks_mcp/registry.py
+++ b/src/databricks_mcp/registry.py
@@ -1,0 +1,105 @@
+"""Capability packs and policy-enforced tool registration.
+
+A *capability pack* is a cohesive group of tools for one Databricks domain
+(catalog, SQL, jobs, ...). Packs register their tools through a :class:`Registrar`,
+which uniformly enforces the policy engine, records tool metadata for
+introspection, and exposes shared helpers. Business logic never imports MCP
+classes directly; only the registrar touches the server object.
+"""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
+
+from databricks_mcp.policy import Capability, PolicyEngine, RiskClass
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+    from databricks_mcp.config import Settings
+    from databricks_mcp.services import DatabricksService
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Policy and operational metadata declared by every registered tool."""
+
+    name: str
+    pack: str
+    risk: RiskClass
+    summary: str
+    changes_state: bool = False
+    cost_sensitive: bool = False
+    supports_dry_run: bool = False
+    idempotent: bool = True
+
+    def describe(self) -> dict[str, object]:
+        """Return a JSON-safe description for capability introspection tools."""
+        return {
+            "name": self.name,
+            "pack": self.pack,
+            "risk": self.risk.value,
+            "summary": self.summary,
+            "changes_state": self.changes_state,
+            "cost_sensitive": self.cost_sensitive,
+            "supports_dry_run": self.supports_dry_run,
+            "idempotent": self.idempotent,
+        }
+
+
+class Registrar:
+    """Registers pack tools onto a FastMCP server with uniform policy checks."""
+
+    def __init__(
+        self,
+        mcp: FastMCP,
+        settings: Settings,
+        policy: PolicyEngine,
+        service_provider: Callable[[], DatabricksService],
+    ) -> None:
+        self._mcp = mcp
+        self.settings = settings
+        self.policy = policy
+        self._service_provider = service_provider
+        self._specs: dict[str, ToolSpec] = {}
+
+    @property
+    def specs(self) -> dict[str, ToolSpec]:
+        """Return registered tool specifications keyed by tool name."""
+        return dict(self._specs)
+
+    @property
+    def service(self) -> DatabricksService:
+        """Resolve the Databricks service lazily, only when a tool needs it."""
+        return self._service_provider()
+
+    def checked_limit(self, limit: int) -> int:
+        """Validate a caller-supplied result limit against the configured ceiling."""
+        maximum = self.settings.maximum_page_size
+        if not 1 <= limit <= maximum:
+            raise ValueError(f"limit must be between 1 and {maximum}")
+        return limit
+
+    def tool(self, spec: ToolSpec) -> Callable[[Callable[P, R]], Callable[P, R]]:
+        """Register ``spec``'s function as an MCP tool guarded by the policy engine."""
+        if spec.name in self._specs:
+            raise ValueError(f"tool '{spec.name}' is already registered")
+
+        def decorator(func: Callable[P, R]) -> Callable[P, R]:
+            self._specs[spec.name] = spec
+
+            @functools.wraps(func)
+            def guarded(*args: P.args, **kwargs: P.kwargs) -> R:
+                self.policy.require(Capability(name=spec.name, risk=spec.risk))
+                return func(*args, **kwargs)
+
+            self._mcp.tool(name=spec.name, description=spec.summary)(guarded)
+            return guarded
+
+        return decorator

--- a/src/databricks_mcp/server.py
+++ b/src/databricks_mcp/server.py
@@ -1,17 +1,14 @@
-"""MCP server construction and tool registration."""
+"""MCP server construction and capability-pack registration."""
 
 from __future__ import annotations
 
-from typing import Any, TypeAlias
-
 from mcp.server.fastmcp import FastMCP
 
-from databricks_mcp import __version__
 from databricks_mcp.config import Settings
-from databricks_mcp.policy import Capability, PolicyEngine, RiskClass
+from databricks_mcp.packs import register_all
+from databricks_mcp.policy import PolicyEngine
+from databricks_mcp.registry import Registrar
 from databricks_mcp.services import DatabricksService
-
-ToolObject: TypeAlias = dict[str, Any]
 
 
 def create_server(
@@ -23,6 +20,7 @@ def create_server(
     """Create an isolated server instance for a process or test."""
     databricks = service
     policy_engine = policy or PolicyEngine()
+
     mcp = FastMCP(
         "DatabricksMCP",
         instructions=(
@@ -33,49 +31,14 @@ def create_server(
         port=settings.port,
     )
 
-    def require_read(name: str) -> None:
-        policy_engine.require(Capability(name=name, risk=RiskClass.READ))
-
-    def get_databricks() -> DatabricksService:
-        # Resolve credentials only when a Databricks-backed tool is called so
-        # the process can start and report health before upstream auth is ready.
+    def service_provider() -> DatabricksService:
+        # Resolve credentials only when a Databricks-backed tool is called so the
+        # process can start and report health before upstream auth is ready.
         nonlocal databricks
         if databricks is None:
             databricks = DatabricksService.from_environment()
         return databricks
 
-    def checked_limit(limit: int) -> int:
-        if not 1 <= limit <= settings.maximum_page_size:
-            raise ValueError(f"limit must be between 1 and {settings.maximum_page_size}")
-        return limit
-
-    @mcp.tool()
-    def health() -> ToolObject:
-        """Return process health without accessing Databricks or exposing credentials."""
-        require_read("health")
-        return {
-            "status": "ok",
-            "version": __version__,
-            "access_mode": settings.access_mode,
-            "transport": settings.transport,
-        }
-
-    @mcp.tool()
-    def current_identity() -> ToolObject:
-        """Return the Databricks identity selected by unified authentication."""
-        require_read("current_identity")
-        return get_databricks().current_identity()
-
-    @mcp.tool()
-    def list_catalogs(limit: int = settings.default_page_size) -> list[ToolObject]:
-        """List accessible Unity Catalog catalogs, bounded to at most 200 results."""
-        require_read("list_catalogs")
-        return get_databricks().list_catalogs(limit=checked_limit(limit))
-
-    @mcp.tool()
-    def list_sql_warehouses(limit: int = settings.default_page_size) -> list[ToolObject]:
-        """List accessible SQL warehouses, bounded to at most 200 results."""
-        require_read("list_sql_warehouses")
-        return get_databricks().list_warehouses(limit=checked_limit(limit))
-
+    registrar = Registrar(mcp, settings, policy_engine, service_provider)
+    register_all(registrar)
     return mcp

--- a/src/databricks_mcp/services.py
+++ b/src/databricks_mcp/services.py
@@ -12,6 +12,11 @@ from collections.abc import Callable, Iterable
 from typing import Protocol
 
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import (
+    Disposition,
+    ExecuteStatementRequestOnWaitTimeout,
+    Format,
+)
 
 from databricks_mcp.serialization import JsonValue, to_json_value
 
@@ -53,6 +58,27 @@ class WarehouseAPI(Protocol):
     def get(self, id: str) -> object: ...
 
 
+class StatementExecutionAPI(Protocol):
+    def execute_statement(
+        self,
+        statement: str,
+        warehouse_id: str,
+        *,
+        byte_limit: int | None = ...,
+        catalog: str | None = ...,
+        disposition: Disposition | None = ...,
+        format: Format | None = ...,
+        on_wait_timeout: ExecuteStatementRequestOnWaitTimeout | None = ...,
+        row_limit: int | None = ...,
+        schema: str | None = ...,
+        wait_timeout: str | None = ...,
+    ) -> object: ...
+
+    def get_statement(self, statement_id: str) -> object: ...
+
+    def cancel_execution(self, statement_id: str) -> object: ...
+
+
 class WorkspaceClientLike(Protocol):
     @property
     def current_user(self) -> CurrentUserAPI: ...
@@ -74,6 +100,9 @@ class WorkspaceClientLike(Protocol):
 
     @property
     def warehouses(self) -> WarehouseAPI: ...
+
+    @property
+    def statement_execution(self) -> StatementExecutionAPI: ...
 
 
 class DatabricksService:
@@ -150,6 +179,38 @@ class DatabricksService:
 
     def get_warehouse(self, warehouse_id: str) -> JsonObject:
         return self._object(self._client.warehouses.get(warehouse_id))
+
+    def execute_read_only_sql(
+        self,
+        *,
+        statement: str,
+        warehouse_id: str,
+        row_limit: int,
+        byte_limit: int,
+        wait_seconds: int,
+        catalog: str | None = None,
+        schema: str | None = None,
+    ) -> JsonObject:
+        response = self._client.statement_execution.execute_statement(
+            statement,
+            warehouse_id,
+            row_limit=row_limit,
+            byte_limit=byte_limit,
+            wait_timeout=f"{wait_seconds}s",
+            on_wait_timeout=ExecuteStatementRequestOnWaitTimeout.CONTINUE,
+            disposition=Disposition.INLINE,
+            format=Format.JSON_ARRAY,
+            catalog=catalog,
+            schema=schema,
+        )
+        return self._object(response)
+
+    def get_sql_statement(self, statement_id: str) -> JsonObject:
+        return self._object(self._client.statement_execution.get_statement(statement_id))
+
+    def cancel_sql_statement(self, statement_id: str) -> JsonObject:
+        self._client.statement_execution.cancel_execution(statement_id)
+        return {"statement_id": statement_id, "cancelled": True}
 
     # -- Serialization helpers -------------------------------------------
 

--- a/src/databricks_mcp/services.py
+++ b/src/databricks_mcp/services.py
@@ -1,9 +1,14 @@
-"""Databricks SDK adapter layer."""
+"""Databricks SDK adapter layer.
+
+Bounded, read-only operations against one Databricks workspace. The service
+accepts an injected client so tests can supply fakes and never reach a live
+workspace. Responses are converted to plain JSON values; SDK models never leave
+this layer.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
-from itertools import islice
+from collections.abc import Callable, Iterable
 from typing import Protocol
 
 from databricks.sdk import WorkspaceClient
@@ -12,6 +17,8 @@ from databricks_mcp.serialization import JsonValue, to_json_value
 
 JsonObject = dict[str, JsonValue]
 
+_VIEW_TABLE_TYPES = frozenset({"VIEW", "MATERIALIZED_VIEW"})
+
 
 class CurrentUserAPI(Protocol):
     def me(self) -> object: ...
@@ -19,10 +26,31 @@ class CurrentUserAPI(Protocol):
 
 class CatalogAPI(Protocol):
     def list(self) -> Iterable[object]: ...
+    def get(self, name: str) -> object: ...
+
+
+class SchemaAPI(Protocol):
+    def list(self, catalog_name: str) -> Iterable[object]: ...
+    def get(self, full_name: str) -> object: ...
+
+
+class TableAPI(Protocol):
+    def list(self, catalog_name: str, schema_name: str) -> Iterable[object]: ...
+    def get(self, full_name: str) -> object: ...
+
+
+class FunctionAPI(Protocol):
+    def list(self, catalog_name: str, schema_name: str) -> Iterable[object]: ...
+    def get(self, name: str) -> object: ...
+
+
+class VolumeAPI(Protocol):
+    def list(self, catalog_name: str, schema_name: str) -> Iterable[object]: ...
 
 
 class WarehouseAPI(Protocol):
     def list(self) -> Iterable[object]: ...
+    def get(self, id: str) -> object: ...
 
 
 class WorkspaceClientLike(Protocol):
@@ -31,6 +59,18 @@ class WorkspaceClientLike(Protocol):
 
     @property
     def catalogs(self) -> CatalogAPI: ...
+
+    @property
+    def schemas(self) -> SchemaAPI: ...
+
+    @property
+    def tables(self) -> TableAPI: ...
+
+    @property
+    def functions(self) -> FunctionAPI: ...
+
+    @property
+    def volumes(self) -> VolumeAPI: ...
 
     @property
     def warehouses(self) -> WarehouseAPI: ...
@@ -47,26 +87,96 @@ class DatabricksService:
         """Build a client using Databricks unified authentication."""
         return cls(WorkspaceClient())
 
+    # -- Identity ---------------------------------------------------------
+
     def current_identity(self) -> JsonObject:
-        identity = to_json_value(self._client.current_user.me())
-        if not isinstance(identity, dict):
-            raise TypeError("Databricks current-user response was not an object")
-        return identity
+        return self._object(self._client.current_user.me())
+
+    # -- Unity Catalog ----------------------------------------------------
 
     def list_catalogs(self, *, limit: int) -> list[JsonObject]:
         return self._bounded(self._client.catalogs.list(), limit=limit)
 
+    def get_catalog(self, name: str) -> JsonObject:
+        return self._object(self._client.catalogs.get(name))
+
+    def list_schemas(self, *, catalog_name: str, limit: int) -> list[JsonObject]:
+        return self._bounded(self._client.schemas.list(catalog_name), limit=limit)
+
+    def get_schema(self, full_name: str) -> JsonObject:
+        return self._object(self._client.schemas.get(full_name))
+
+    def list_tables(self, *, catalog_name: str, schema_name: str, limit: int) -> list[JsonObject]:
+        return self._bounded(self._client.tables.list(catalog_name, schema_name), limit=limit)
+
+    def get_table(self, full_name: str) -> JsonObject:
+        return self._object(self._client.tables.get(full_name))
+
+    def list_views(self, *, catalog_name: str, schema_name: str, limit: int) -> list[JsonObject]:
+        return self._bounded(
+            self._client.tables.list(catalog_name, schema_name),
+            limit=limit,
+            predicate=lambda table: table.get("table_type") in _VIEW_TABLE_TYPES,
+        )
+
+    def list_columns(self, full_name: str) -> list[JsonObject]:
+        columns = self.get_table(full_name).get("columns")
+        if columns is None:
+            return []
+        if not isinstance(columns, list):
+            raise TypeError("Databricks table columns response was not a list")
+        result: list[JsonObject] = []
+        for column in columns:
+            if not isinstance(column, dict):
+                raise TypeError("Databricks table column entry was not an object")
+            result.append(column)
+        return result
+
+    def list_functions(
+        self, *, catalog_name: str, schema_name: str, limit: int
+    ) -> list[JsonObject]:
+        return self._bounded(self._client.functions.list(catalog_name, schema_name), limit=limit)
+
+    def get_function(self, name: str) -> JsonObject:
+        return self._object(self._client.functions.get(name))
+
+    def list_volumes(self, *, catalog_name: str, schema_name: str, limit: int) -> list[JsonObject]:
+        return self._bounded(self._client.volumes.list(catalog_name, schema_name), limit=limit)
+
+    # -- Databricks SQL ---------------------------------------------------
+
     def list_warehouses(self, *, limit: int) -> list[JsonObject]:
         return self._bounded(self._client.warehouses.list(), limit=limit)
 
+    def get_warehouse(self, warehouse_id: str) -> JsonObject:
+        return self._object(self._client.warehouses.get(warehouse_id))
+
+    # -- Serialization helpers -------------------------------------------
+
     @staticmethod
-    def _bounded(values: Iterable[object], *, limit: int) -> list[JsonObject]:
+    def _object(value: object) -> JsonObject:
+        serialized = to_json_value(value)
+        if not isinstance(serialized, dict):
+            raise TypeError("Databricks response was not an object")
+        return serialized
+
+    @staticmethod
+    def _bounded(
+        values: Iterable[object],
+        *,
+        limit: int,
+        predicate: Callable[[JsonObject], bool] | None = None,
+    ) -> list[JsonObject]:
         if limit < 1:
             raise ValueError("limit must be greater than zero")
         results: list[JsonObject] = []
-        for value in islice(values, limit):
+        for value in values:
+            if len(results) >= limit:
+                break
             serialized = to_json_value(value)
             if not isinstance(serialized, dict):
                 raise TypeError("Databricks list response contained a non-object item")
+            if predicate is not None and not predicate(serialized):
+                continue
             results.append(serialized)
         return results

--- a/src/databricks_mcp/sqlguard.py
+++ b/src/databricks_mcp/sqlguard.py
@@ -1,0 +1,117 @@
+"""Read-only SQL validation through sqlglot AST inspection.
+
+The guard parses a statement with the Databricks dialect and permits only
+queries that cannot change state: ``SELECT`` (including set operations and
+CTEs), ``DESCRIBE``, ``SHOW``, and ``EXPLAIN`` wrapping a permitted query.
+Everything else — DML, DDL, session/administrative commands, and multiple
+statements — is rejected. Rejection is the default: anything that does not
+parse, or that the guard does not positively recognize as read-only, is denied.
+"""
+
+from __future__ import annotations
+
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import ParseError
+
+DIALECT = "databricks"
+
+# Query-shaped roots that are inherently read-only.
+_ALLOWED_QUERY_TYPES: tuple[type[exp.Expression], ...] = (
+    exp.Select,
+    exp.Union,
+    exp.Intersect,
+    exp.Except,
+    exp.Subquery,
+    exp.Describe,
+)
+
+# State-changing or privileged nodes rejected anywhere in the tree.
+_FORBIDDEN_TYPES: tuple[type[exp.Expression], ...] = (
+    exp.Insert,
+    exp.Update,
+    exp.Delete,
+    exp.Merge,
+    exp.Create,
+    exp.Drop,
+    exp.Alter,
+    exp.TruncateTable,
+    exp.Copy,
+    exp.Set,
+    exp.Use,
+    exp.Grant,
+    exp.Refresh,
+)
+
+# Modifiers that may follow EXPLAIN before the wrapped query.
+_EXPLAIN_MODIFIERS = frozenset({"EXTENDED", "FORMATTED", "CODEGEN", "COST", "LOGICAL"})
+_MAX_EXPLAIN_DEPTH = 2
+
+
+class UnsafeSqlError(ValueError):
+    """Raised when a statement is not a permitted read-only query."""
+
+
+def validate_read_only_sql(sql: str) -> str:
+    """Return the trimmed statement if it is read-only; raise otherwise."""
+    text = sql.strip()
+    if not text:
+        raise UnsafeSqlError("empty SQL statement")
+    statements = _parse(text)
+    if len(statements) > 1:
+        raise UnsafeSqlError("multiple SQL statements are not allowed")
+    _validate_statement(statements[0], depth=0)
+    return text
+
+
+def _parse(text: str) -> list[exp.Expression]:
+    try:
+        parsed = sqlglot.parse(text, read=DIALECT)
+    except ParseError as error:
+        raise UnsafeSqlError(f"could not parse SQL: {error}") from error
+    statements = [statement for statement in parsed if statement is not None]
+    if not statements:
+        raise UnsafeSqlError("no SQL statement found")
+    return statements
+
+
+def _validate_statement(node: exp.Expression, *, depth: int) -> None:
+    if isinstance(node, exp.Command):
+        _validate_command(node, depth=depth)
+        return
+    if isinstance(node, _ALLOWED_QUERY_TYPES):
+        forbidden = next(node.find_all(*_FORBIDDEN_TYPES), None)
+        if forbidden is not None:
+            raise UnsafeSqlError(f"'{forbidden.key.upper()}' is not permitted in read-only SQL")
+        if next(node.find_all(exp.Command), None) is not None:
+            raise UnsafeSqlError("nested non-query command is not permitted")
+        return
+    raise UnsafeSqlError(f"statement type '{node.key.upper()}' is not read-only")
+
+
+def _validate_command(node: exp.Command, *, depth: int) -> None:
+    keyword = str(node.this or "").upper()
+    if keyword == "SHOW":
+        return
+    if keyword == "EXPLAIN":
+        if depth >= _MAX_EXPLAIN_DEPTH:
+            raise UnsafeSqlError("EXPLAIN is nested too deeply")
+        inner = _explain_target(node)
+        target = _parse(inner)
+        if len(target) != 1:
+            raise UnsafeSqlError("EXPLAIN must wrap exactly one query")
+        _validate_statement(target[0], depth=depth + 1)
+        return
+    raise UnsafeSqlError(f"command '{keyword}' is not read-only")
+
+
+def _explain_target(node: exp.Command) -> str:
+    expression = node.args.get("expression")
+    remainder = str(expression.this) if isinstance(expression, exp.Literal) else ""
+    tokens = remainder.split()
+    while tokens and tokens[0].upper() in _EXPLAIN_MODIFIERS:
+        tokens = tokens[1:]
+    inner = " ".join(tokens)
+    if not inner:
+        raise UnsafeSqlError("EXPLAIN requires a query")
+    return inner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,27 @@ class WarehouseAPI:
         return Model(id=id, name="starter", state="RUNNING")
 
 
+class StatementExecutionAPI:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.cancelled: list[str] = []
+
+    def execute_statement(self, statement: str, warehouse_id: str, **kwargs: object) -> Model:
+        self.calls.append({"statement": statement, "warehouse_id": warehouse_id, **kwargs})
+        return Model(
+            statement_id="stmt-1",
+            status={"state": "SUCCEEDED"},
+            result={"data_array": [["1"]]},
+        )
+
+    def get_statement(self, statement_id: str) -> Model:
+        return Model(statement_id=statement_id, status={"state": "SUCCEEDED"})
+
+    def cancel_execution(self, statement_id: str) -> None:
+        self.cancelled.append(statement_id)
+        return None
+
+
 class FakeWorkspaceClient:
     """A structural stand-in for ``databricks.sdk.WorkspaceClient``."""
 
@@ -97,3 +118,4 @@ class FakeWorkspaceClient:
         self.functions = FunctionAPI()
         self.volumes = VolumeAPI()
         self.warehouses = WarehouseAPI()
+        self.statement_execution = StatementExecutionAPI()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,99 @@
+"""Shared fakes that emulate the Databricks SDK surface used by the service."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+
+class Model:
+    """A minimal SDK-like model exposing ``as_dict`` for serialization."""
+
+    def __init__(self, **fields: object) -> None:
+        self._fields = fields
+
+    def as_dict(self) -> dict[str, object]:
+        return dict(self._fields)
+
+
+class CurrentUser:
+    def me(self) -> Model:
+        return Model(userName="user@example.com")
+
+
+class CatalogAPI:
+    def list(self) -> Iterator[Model]:
+        yield from (Model(name=name) for name in ("main", "system", "samples"))
+
+    def get(self, name: str) -> Model:
+        return Model(name=name, comment=f"catalog {name}")
+
+
+class SchemaAPI:
+    def __init__(self) -> None:
+        self.list_calls: list[str] = []
+
+    def list(self, catalog_name: str) -> Iterator[Model]:
+        self.list_calls.append(catalog_name)
+        yield from (Model(name=name, catalog_name=catalog_name) for name in ("default", "bronze"))
+
+    def get(self, full_name: str) -> Model:
+        return Model(full_name=full_name)
+
+
+class TableAPI:
+    def __init__(self) -> None:
+        self.list_calls: list[tuple[str, str]] = []
+
+    def list(self, catalog_name: str, schema_name: str) -> Iterator[Model]:
+        self.list_calls.append((catalog_name, schema_name))
+        yield Model(name="events", table_type="MANAGED")
+        yield Model(name="daily_view", table_type="VIEW")
+        yield Model(name="rollup", table_type="MATERIALIZED_VIEW")
+
+    def get(self, full_name: str) -> Model:
+        return Model(
+            full_name=full_name,
+            catalog_name="main",
+            schema_name="default",
+            name="events",
+            table_type="MANAGED",
+            comment="event log",
+            columns=[
+                {"name": "id", "type_text": "bigint", "nullable": False, "comment": "pk"},
+                {"name": "ts", "type_text": "timestamp", "nullable": True, "comment": None},
+            ],
+        )
+
+
+class FunctionAPI:
+    def list(self, catalog_name: str, schema_name: str) -> Iterator[Model]:
+        yield Model(name="to_upper", catalog_name=catalog_name, schema_name=schema_name)
+
+    def get(self, name: str) -> Model:
+        return Model(name=name)
+
+
+class VolumeAPI:
+    def list(self, catalog_name: str, schema_name: str) -> Iterator[Model]:
+        yield Model(name="raw", catalog_name=catalog_name, schema_name=schema_name)
+
+
+class WarehouseAPI:
+    def list(self) -> Iterator[Model]:
+        yield Model(id="w1", name="starter")
+
+    def get(self, id: str) -> Model:
+        return Model(id=id, name="starter", state="RUNNING")
+
+
+class FakeWorkspaceClient:
+    """A structural stand-in for ``databricks.sdk.WorkspaceClient``."""
+
+    def __init__(self) -> None:
+        self.current_user = CurrentUser()
+        self.catalogs = CatalogAPI()
+        self.schemas = SchemaAPI()
+        self.tables = TableAPI()
+        self.functions = FunctionAPI()
+        self.volumes = VolumeAPI()
+        self.warehouses = WarehouseAPI()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from databricks_mcp.config import Settings
+from databricks_mcp.policy import PolicyDeniedError, PolicyEngine, RiskClass
+from databricks_mcp.registry import Registrar, ToolSpec
+from databricks_mcp.services import DatabricksService
+from tests.conftest import FakeWorkspaceClient
+
+
+def _registrar() -> Registrar:
+    mcp = FastMCP("test")
+    return Registrar(
+        mcp,
+        Settings(),
+        PolicyEngine(),
+        lambda: DatabricksService(FakeWorkspaceClient()),
+    )
+
+
+def test_read_tool_is_allowed_and_recorded() -> None:
+    registrar = _registrar()
+
+    @registrar.tool(ToolSpec("ping", "core", RiskClass.READ, "ping"))
+    def ping() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    assert ping() == {"ok": "yes"}
+    assert registrar.specs["ping"].risk is RiskClass.READ
+
+
+def test_write_tool_is_denied_by_policy() -> None:
+    registrar = _registrar()
+
+    @registrar.tool(ToolSpec("mutate", "core", RiskClass.WRITE, "mutate", changes_state=True))
+    def mutate() -> dict[str, str]:
+        return {"done": "yes"}
+
+    with pytest.raises(PolicyDeniedError):
+        mutate()
+
+
+def test_duplicate_registration_is_rejected() -> None:
+    registrar = _registrar()
+
+    @registrar.tool(ToolSpec("dup", "core", RiskClass.READ, "dup"))
+    def first() -> dict[str, str]:
+        return {}
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @registrar.tool(ToolSpec("dup", "core", RiskClass.READ, "dup again"))
+        def second() -> dict[str, str]:
+            return {}
+
+
+def test_checked_limit_enforces_ceiling() -> None:
+    registrar = _registrar()
+    assert registrar.checked_limit(50) == 50
+    with pytest.raises(ValueError, match="between 1 and 200"):
+        registrar.checked_limit(0)
+    with pytest.raises(ValueError, match="between 1 and 200"):
+        registrar.checked_limit(201)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,61 +1,116 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+
+import pytest
 
 from databricks_mcp.config import Settings
 from databricks_mcp.server import create_server
 from databricks_mcp.services import DatabricksService
+from tests.conftest import FakeWorkspaceClient
+
+EXPECTED_TOOLS = {
+    # core
+    "health",
+    "server_info",
+    "list_enabled_capabilities",
+    "get_policy_status",
+    "current_identity",
+    # catalog
+    "list_catalogs",
+    "get_catalog",
+    "list_schemas",
+    "get_schema",
+    "list_tables",
+    "list_views",
+    "get_table",
+    "describe_table",
+    "list_columns",
+    "list_functions",
+    "get_function",
+    "list_volumes",
+    # sql
+    "list_sql_warehouses",
+    "get_sql_warehouse",
+}
 
 
-class Model:
-    def as_dict(self) -> dict[str, object]:
-        return {"name": "example"}
+def _server() -> object:
+    return create_server(Settings(), service=DatabricksService(FakeWorkspaceClient()))
 
 
-class CurrentUser:
-    def me(self) -> object:
-        return Model()
-
-
-class ListingAPI:
-    def list(self) -> Iterable[object]:
-        return [Model()]
-
-
-class FakeWorkspaceClient:
-    def __init__(self) -> None:
-        self.current_user = CurrentUser()
-        self.catalogs = ListingAPI()
-        self.warehouses = ListingAPI()
-
-
-def test_tool_schemas_are_registered_and_resolvable() -> None:
-    server = create_server(
-        Settings(),
-        service=DatabricksService(FakeWorkspaceClient()),
-    )
-
+def test_all_tools_register_with_schemas() -> None:
+    server = _server()
     tools = asyncio.run(server.list_tools())
-
-    assert {tool.name for tool in tools} == {
-        "health",
-        "current_identity",
-        "list_catalogs",
-        "list_sql_warehouses",
-    }
+    assert {tool.name for tool in tools} == EXPECTED_TOOLS
     assert all(tool.outputSchema is not None for tool in tools)
+    assert all(tool.description for tool in tools)
 
 
 def test_health_does_not_require_databricks_credentials() -> None:
     server = create_server(Settings())
-
-    content, structured = asyncio.run(server.call_tool("health", {}))
-
-    assert content
+    _content, structured = asyncio.run(server.call_tool("health", {}))
     assert structured == {
         "status": "ok",
         "version": "0.1.0.dev0",
         "access_mode": "read-only",
         "transport": "stdio",
     }
+
+
+def test_current_identity_flows_through_service() -> None:
+    server = _server()
+    _content, structured = asyncio.run(server.call_tool("current_identity", {}))
+    assert structured == {"userName": "user@example.com"}
+
+
+def test_describe_table_returns_concise_summary() -> None:
+    server = _server()
+    _content, structured = asyncio.run(
+        server.call_tool("describe_table", {"full_name": "main.default.events"})
+    )
+    assert structured["table_type"] == "MANAGED"
+    assert [column["name"] for column in structured["columns"]] == ["id", "ts"]
+    assert structured["columns"][0]["type"] == "bigint"
+
+
+def test_server_info_reports_packs_and_tool_count() -> None:
+    server = _server()
+    _content, structured = asyncio.run(server.call_tool("server_info", {}))
+    assert structured["packs"] == ["catalog", "core", "sql"]
+    assert structured["tool_count"] == len(EXPECTED_TOOLS)
+
+
+def test_list_enabled_capabilities_reports_read_risk() -> None:
+    server = _server()
+    _content, structured = asyncio.run(server.call_tool("list_enabled_capabilities", {}))
+    capabilities = structured["result"]
+    assert {cap["risk"] for cap in capabilities} == {"read"}
+    assert len(capabilities) == len(EXPECTED_TOOLS)
+
+
+# Every catalog/sql tool exercised end-to-end through the server against the fake
+# workspace, so each tool body and its argument wiring is covered.
+_TOOL_CALLS = [
+    ("list_catalogs", {}),
+    ("get_catalog", {"name": "main"}),
+    ("list_schemas", {"catalog_name": "main"}),
+    ("get_schema", {"full_name": "main.default"}),
+    ("list_tables", {"catalog_name": "main", "schema_name": "default"}),
+    ("list_views", {"catalog_name": "main", "schema_name": "default"}),
+    ("get_table", {"full_name": "main.default.events"}),
+    ("list_columns", {"full_name": "main.default.events"}),
+    ("list_functions", {"catalog_name": "main", "schema_name": "default"}),
+    ("get_function", {"name": "main.default.to_upper"}),
+    ("list_volumes", {"catalog_name": "main", "schema_name": "default"}),
+    ("list_sql_warehouses", {}),
+    ("get_sql_warehouse", {"warehouse_id": "w1"}),
+]
+
+
+@pytest.mark.parametrize(("tool", "args"), _TOOL_CALLS)
+def test_read_tool_invocation_succeeds(tool: str, args: dict[str, str]) -> None:
+    server = _server()
+    content, structured = asyncio.run(server.call_tool(tool, args))
+    assert content
+    assert structured is not None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,6 +32,10 @@ EXPECTED_TOOLS = {
     # sql
     "list_sql_warehouses",
     "get_sql_warehouse",
+    "execute_read_only_sql",
+    "explain_sql",
+    "get_sql_statement",
+    "cancel_sql_statement",
 }
 
 
@@ -105,6 +109,10 @@ _TOOL_CALLS = [
     ("list_volumes", {"catalog_name": "main", "schema_name": "default"}),
     ("list_sql_warehouses", {}),
     ("get_sql_warehouse", {"warehouse_id": "w1"}),
+    ("execute_read_only_sql", {"statement": "SELECT 1", "warehouse_id": "w1"}),
+    ("explain_sql", {"statement": "SELECT 1", "warehouse_id": "w1"}),
+    ("get_sql_statement", {"statement_id": "stmt-1"}),
+    ("cancel_sql_statement", {"statement_id": "stmt-1"}),
 ]
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,52 +1,58 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 import pytest
 
 from databricks_mcp.services import DatabricksService
+from tests.conftest import FakeWorkspaceClient
 
 
-class Model:
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-    def as_dict(self) -> dict[str, object]:
-        return {"name": self.name}
-
-
-class CurrentUser:
-    def me(self) -> object:
-        return Model("user@example.com")
-
-
-class ListingAPI:
-    def __init__(self, names: list[str]) -> None:
-        self.names = names
-
-    def list(self) -> Iterable[object]:
-        return (Model(name) for name in self.names)
-
-
-class FakeWorkspaceClient:
-    def __init__(self) -> None:
-        self.current_user = CurrentUser()
-        self.catalogs = ListingAPI(["main", "system", "samples"])
-        self.warehouses = ListingAPI(["starter"])
+def _service() -> DatabricksService:
+    return DatabricksService(FakeWorkspaceClient())
 
 
 def test_current_identity_is_serialized() -> None:
-    service = DatabricksService(FakeWorkspaceClient())
-    assert service.current_identity() == {"name": "user@example.com"}
+    assert _service().current_identity() == {"userName": "user@example.com"}
 
 
-def test_lists_are_bounded() -> None:
-    service = DatabricksService(FakeWorkspaceClient())
-    assert service.list_catalogs(limit=2) == [{"name": "main"}, {"name": "system"}]
-    assert service.list_warehouses(limit=10) == [{"name": "starter"}]
+def test_list_catalogs_is_bounded() -> None:
+    assert _service().list_catalogs(limit=2) == [{"name": "main"}, {"name": "system"}]
+
+
+def test_get_catalog_returns_object() -> None:
+    assert _service().get_catalog("main") == {"name": "main", "comment": "catalog main"}
+
+
+def test_list_schemas_passes_catalog_name() -> None:
+    client = FakeWorkspaceClient()
+    service = DatabricksService(client)
+    result = service.list_schemas(catalog_name="main", limit=10)
+    assert client.schemas.list_calls == ["main"]
+    assert result == [
+        {"name": "default", "catalog_name": "main"},
+        {"name": "bronze", "catalog_name": "main"},
+    ]
+
+
+def test_list_tables_passes_catalog_and_schema() -> None:
+    client = FakeWorkspaceClient()
+    DatabricksService(client).list_tables(catalog_name="main", schema_name="default", limit=10)
+    assert client.tables.list_calls == [("main", "default")]
+
+
+def test_list_views_filters_to_view_types() -> None:
+    views = _service().list_views(catalog_name="main", schema_name="default", limit=10)
+    assert [view["name"] for view in views] == ["daily_view", "rollup"]
+
+
+def test_list_columns_extracts_columns_from_table() -> None:
+    columns = _service().list_columns("main.default.events")
+    assert [column["name"] for column in columns] == ["id", "ts"]
+
+
+def test_get_warehouse_returns_object() -> None:
+    assert _service().get_warehouse("w1") == {"id": "w1", "name": "starter", "state": "RUNNING"}
 
 
 def test_invalid_limit_is_rejected() -> None:
-    service = DatabricksService(FakeWorkspaceClient())
     with pytest.raises(ValueError, match="greater than zero"):
-        service.list_catalogs(limit=0)
+        _service().list_catalogs(limit=0)

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from databricks_mcp.config import Settings
+from databricks_mcp.server import create_server
+from databricks_mcp.services import DatabricksService
+from tests.conftest import FakeWorkspaceClient
+
+
+def _server_with_client(client: FakeWorkspaceClient, settings: Settings | None = None) -> object:
+    return create_server(settings or Settings(), service=DatabricksService(client))
+
+
+def test_execute_read_only_sql_passes_bounded_request() -> None:
+    client = FakeWorkspaceClient()
+    server = _server_with_client(client)
+    _content, structured = asyncio.run(
+        server.call_tool(
+            "execute_read_only_sql",
+            {"statement": "SELECT 1", "warehouse_id": "w1", "max_rows": 5},
+        )
+    )
+    assert structured["statement_id"] == "stmt-1"
+    call = client.statement_execution.calls[0]
+    assert call["statement"] == "SELECT 1"
+    assert call["warehouse_id"] == "w1"
+    assert call["row_limit"] == 5
+    assert call["byte_limit"] == Settings().sql_byte_limit
+    assert call["wait_timeout"] == "30s"
+
+
+def test_execute_read_only_sql_clamps_max_rows_to_ceiling() -> None:
+    client = FakeWorkspaceClient()
+    server = _server_with_client(client, Settings(sql_max_rows=10))
+    asyncio.run(
+        server.call_tool(
+            "execute_read_only_sql",
+            {"statement": "SELECT 1", "warehouse_id": "w1", "max_rows": 9999},
+        )
+    )
+    assert client.statement_execution.calls[0]["row_limit"] == 10
+
+
+def test_execute_read_only_sql_rejects_mutations() -> None:
+    client = FakeWorkspaceClient()
+    server = _server_with_client(client)
+    with pytest.raises(Exception, match=r"read-only|not permitted|parse"):
+        asyncio.run(
+            server.call_tool(
+                "execute_read_only_sql",
+                {"statement": "DROP TABLE t", "warehouse_id": "w1"},
+            )
+        )
+    assert client.statement_execution.calls == []
+
+
+def test_execute_read_only_sql_enforces_warehouse_allowlist() -> None:
+    client = FakeWorkspaceClient()
+    server = _server_with_client(client, Settings(sql_warehouse_allowlist=("allowed",)))
+    with pytest.raises(Exception, match="allowlist"):
+        asyncio.run(
+            server.call_tool(
+                "execute_read_only_sql",
+                {"statement": "SELECT 1", "warehouse_id": "w1"},
+            )
+        )
+
+
+def test_cancel_sql_statement_calls_sdk() -> None:
+    client = FakeWorkspaceClient()
+    service = DatabricksService(client)
+    assert service.cancel_sql_statement("stmt-9") == {"statement_id": "stmt-9", "cancelled": True}
+    assert client.statement_execution.cancelled == ["stmt-9"]
+
+
+def test_explain_sql_wraps_statement_with_explain() -> None:
+    client = FakeWorkspaceClient()
+    server = _server_with_client(client)
+    asyncio.run(server.call_tool("explain_sql", {"statement": "SELECT 1", "warehouse_id": "w1"}))
+    assert client.statement_execution.calls[0]["statement"] == "EXPLAIN SELECT 1"

--- a/tests/test_sqlguard.py
+++ b/tests/test_sqlguard.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+
+from databricks_mcp.sqlguard import UnsafeSqlError, validate_read_only_sql
+
+ALLOWED = [
+    "SELECT 1",
+    "select * from main.default.events where id > 10 limit 5",
+    "WITH c AS (SELECT * FROM t) SELECT * FROM c",
+    "SELECT a FROM t UNION SELECT b FROM u",
+    "(SELECT 1)",
+    "SHOW TABLES IN main.default",
+    "SHOW CATALOGS",
+    "DESCRIBE TABLE main.default.events",
+    "DESC main.default.events",
+    "EXPLAIN SELECT * FROM t",
+    "EXPLAIN EXTENDED SELECT * FROM t",
+]
+
+DENIED = [
+    "INSERT INTO t VALUES (1)",
+    "UPDATE t SET x = 1",
+    "DELETE FROM t",
+    "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET x = 1",
+    "DROP TABLE t",
+    "CREATE TABLE t (a int)",
+    "ALTER TABLE t ADD COLUMN b int",
+    "TRUNCATE TABLE t",
+    "COPY INTO t FROM '/x'",
+    "SET spark.sql.shuffle.partitions = 1",
+    "USE CATALOG main",
+    "GRANT SELECT ON t TO u",
+    "REFRESH TABLE t",
+    "OPTIMIZE t",
+    "VACUUM t",
+    # Injection / bypass attempts.
+    "SELECT * FROM t; DROP TABLE t",
+    "SELECT * FROM t; SELECT * FROM u",
+    "EXPLAIN DROP TABLE t",
+    "EXPLAIN INSERT INTO t VALUES (1)",
+    # Not a statement.
+    "",
+    "   ",
+    "this is not sql !!!",
+]
+
+
+@pytest.mark.parametrize("sql", ALLOWED)
+def test_read_only_statements_are_allowed(sql: str) -> None:
+    assert validate_read_only_sql(sql) == sql.strip()
+
+
+@pytest.mark.parametrize("sql", DENIED)
+def test_unsafe_statements_are_rejected(sql: str) -> None:
+    with pytest.raises(UnsafeSqlError):
+        validate_read_only_sql(sql)

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,7 @@ source = { editable = "." }
 dependencies = [
     { name = "databricks-sdk" },
     { name = "mcp" },
+    { name = "sqlglot" },
 ]
 
 [package.dev-dependencies]
@@ -419,6 +420,7 @@ dev = [
 requires-dist = [
     { name = "databricks-sdk", specifier = ">=0.57.0,<1" },
     { name = "mcp", specifier = ">=1.9.0,<2" },
+    { name = "sqlglot", specifier = ">=25,<28" },
 ]
 
 [package.metadata.requires-dev]
@@ -1308,6 +1310,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
     { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
     { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "27.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/50/766692a83468adb1bde9e09ea524a01719912f6bc4fdb47ec18368320f6e/sqlglot-27.29.0.tar.gz", hash = "sha256:2270899694663acef94fa93497971837e6fadd712f4a98b32aee1e980bc82722", size = 5503507, upload-time = "2025-10-29T13:50:24.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/70/20c1912bc0bfebf516d59d618209443b136c58a7cff141afa7cf30969988/sqlglot-27.29.0-py3-none-any.whl", hash = "sha256:9a5ea8ac61826a7763de10cad45a35f0aa9bfcf7b96ee74afb2314de9089e1cb", size = 526060, upload-time = "2025-10-29T13:50:22.061Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Grows the Phase 1 read-only foundation from **4 tools to 23**, all read-only and
policy-guarded. Introduces a capability-pack architecture that future Databricks
domains plug into, completes Unity Catalog metadata exploration, and adds bounded,
AST-validated read-only SQL execution. Additive and within the Phase 1 safety
envelope: no mutation tools, deny-by-default policy, bounded results.

## What's included

**1. Capability-pack architecture**
- `registry.py` — `ToolSpec` (risk class + operational metadata) and a `Registrar`
  that enforces the policy engine on every tool call and records metadata.
- `packs/` — one module per domain (`core`, `catalog`, `sql`), each exposing
  `register(registrar)`. `server.py` just wires the registrar and registers packs.

**2. Core / diagnostics pack**
- `server_info`, `list_enabled_capabilities`, `get_policy_status`.

**3. Unity Catalog read pack**
- `get_catalog`, `list_schemas`, `get_schema`, `list_tables`, `list_views`,
  `get_table`, `describe_table`, `list_columns`, `list_functions`, `get_function`,
  `list_volumes`.

**4. AST-validated read-only SQL pack**
- `sqlguard.py` — sqlglot guard that default-denies, allowing only SELECT (incl.
  set ops and CTEs), DESCRIBE, SHOW, and EXPLAIN wrapping a permitted query.
  Rejects DML/DDL, session/admin commands, multiple statements, and EXPLAIN-wrapped
  mutations.
- `execute_read_only_sql` (guard + row/byte/wait limits + optional warehouse
  allowlist), `explain_sql`, `get_sql_statement`, `cancel_sql_statement`.
- New config: `DATABRICKS_MCP_SQL_MAX_ROWS`, `DATABRICKS_MCP_SQL_BYTE_LIMIT`,
  `DATABRICKS_MCP_SQL_WAIT_SECONDS`, `DATABRICKS_MCP_SQL_WAREHOUSES`.

## Testing

- 88 tests, 94% coverage; ruff, ruff format, and mypy --strict all clean.
- Every read tool exercised end-to-end through the server; registry test confirms a
  WRITE-classified tool is denied by policy.
- SQL guard: 22 allow/deny cases incl. bypass attempts (`SELECT 1; DROP TABLE t`,
  `EXPLAIN DROP TABLE t`).
- Verified as a real MCP process over stdio: handshake, all 23 tools discovered,
  guard rejects mutations before any network call, workspace tools fail gracefully
  without auth.

## Reviewer notes

- **`uv.lock` is not regenerated** — `sqlglot` was added to `pyproject.toml`;
  run `uv lock` and commit the lockfile or CI's `uv sync --locked` will fail.
- `sqlglot` added as a runtime dependency (`>=25,<28`); mypy override added (no stubs).
- No behavioral change to existing tools beyond `list_sql_warehouses` moving into
  the `sql` pack (name/contract unchanged).